### PR TITLE
Add support for librealsense 1.9.7 + fix compilation on Linux and a few more calls

### DIFF
--- a/examples/get_depth.py
+++ b/examples/get_depth.py
@@ -1,4 +1,4 @@
-from pyrealsense import Device, Stream, Format
+from pyrealsense import Device, Stream, Format, Option
 import numpy as np
 import cv2
 
@@ -12,7 +12,13 @@ def main():
     print('Name:', dev.get_name())
     print('Serial:', dev.get_serial())
     print('Port ID:', dev.get_usb_port_id())
+    print('Firmware version:', dev.get_firmware_version())
+    print('One meter:', 1.0/dev.get_depth_scale())
     print('Press esc key to stop')
+
+    if dev.supports_option(Option.r200_lr_auto_exposure_enabled):
+        dev.set_option(Option.r200_lr_auto_exposure_enabled, 1)
+        print('Auto exposure: ', dev.get_option(Option.r200_lr_auto_exposure_enabled))
 
     # XXX: librealsense requires the three streams to activate it. WHY?
     dev.enable_stream(Stream.depth, 640, 480, Format.z16, 30)

--- a/pyrealsense/__init__.py
+++ b/pyrealsense/__init__.py
@@ -4,3 +4,4 @@ from pyrealsense import enum
 Device = core.Device
 Format = enum.Format
 Stream = enum.Stream
+Option = enum.Option

--- a/pyrealsense/core.pyx
+++ b/pyrealsense/core.pyx
@@ -49,13 +49,23 @@ cdef dict FORMAT_CONFIG = {
     Format.y16: (1, np.dtype('u2')),
 }
 
-cdef dict STREAM_TO_RAW = {
+cdef dict STREAM_TO_FORMAT = {
     # TODO what should be used for Stream.points? Color? 4 channels?
     Stream.rectified_color: Stream.color,
     Stream.color_aligned_to_depth: Stream.color,
     Stream.infrared2_aligned_to_depth: Stream.infrared2,
     Stream.depth_aligned_to_color: Stream.depth,
     Stream.depth_aligned_to_rectified_color: Stream.depth,
+    Stream.depth_aligned_to_infrared2: Stream.depth
+}
+
+cdef dict STREAM_TO_DIMENSIONS = {
+    # TODO what should be used for Stream.points? Color? 4 channels?
+    Stream.rectified_color: Stream.color,
+    Stream.color_aligned_to_depth: Stream.color,
+    Stream.infrared2_aligned_to_depth: Stream.infrared2,
+    Stream.depth_aligned_to_color: Stream.color,
+    Stream.depth_aligned_to_rectified_color: Stream.color,
     Stream.depth_aligned_to_infrared2: Stream.depth
 }
 
@@ -121,10 +131,11 @@ cdef class Device:
 
     cpdef np.ndarray get_frame_data(self, int stream):
         cdef void* src_ptr = <void*>self._device.get_frame_data(<StreamType>stream)
-        cdef int stream_key = STREAM_TO_RAW[stream] if STREAM_TO_RAW.has_key(stream) else stream
-        cdef int width = self.stream_width[stream_key]
-        cdef int height = self.stream_height[stream_key]
-        cdef int fmt = self.stream_format[stream_key]
+        cdef int format_key = STREAM_TO_FORMAT[stream] if STREAM_TO_FORMAT.has_key(stream) else stream
+        cdef int dimensions_key = STREAM_TO_DIMENSIONS[stream] if STREAM_TO_DIMENSIONS.has_key(stream) else stream
+        cdef int width = self.stream_width[dimensions_key]
+        cdef int height = self.stream_height[dimensions_key]
+        cdef int fmt = self.stream_format[format_key]
         channel, dtype = FORMAT_CONFIG[fmt]
         shape = (height, width) if channel == 1 else (height, width, channel)
         dst_arr = np.zeros(shape, dtype=dtype)

--- a/pyrealsense/core.pyx
+++ b/pyrealsense/core.pyx
@@ -49,6 +49,16 @@ cdef dict FORMAT_CONFIG = {
     Format.y16: (1, np.dtype('u2')),
 }
 
+cdef dict STREAM_TO_RAW = {
+    # TODO what should be used for Stream.points? Color? 4 channels?
+    Stream.rectified_color: Stream.color,
+    Stream.color_aligned_to_depth: Stream.color,
+    Stream.infrared2_aligned_to_depth: Stream.infrared2,
+    Stream.depth_aligned_to_color: Stream.depth,
+    Stream.depth_aligned_to_rectified_color: Stream.depth,
+    Stream.depth_aligned_to_infrared2: Stream.depth
+}
+
 cdef class Device:
 
     cdef context* _context
@@ -92,6 +102,7 @@ cdef class Device:
             self, int stream, int width, int height, int fmt, int framerate):
         self._device.enable_stream(
             <StreamType>stream, width, height, <FormatType>fmt, framerate)
+
         self.stream_width[stream] = width
         self.stream_height[stream] = height
         self.stream_format[stream] = fmt
@@ -110,9 +121,10 @@ cdef class Device:
 
     cpdef np.ndarray get_frame_data(self, int stream):
         cdef void* src_ptr = <void*>self._device.get_frame_data(<StreamType>stream)
-        cdef int width = self.stream_width[stream]
-        cdef int height = self.stream_height[stream]
-        cdef int fmt = self.stream_format[stream]
+        cdef int stream_key = STREAM_TO_RAW[stream] if STREAM_TO_RAW.has_key(stream) else stream
+        cdef int width = self.stream_width[stream_key]
+        cdef int height = self.stream_height[stream_key]
+        cdef int fmt = self.stream_format[stream_key]
         channel, dtype = FORMAT_CONFIG[fmt]
         shape = (height, width) if channel == 1 else (height, width, channel)
         dst_arr = np.zeros(shape, dtype=dtype)

--- a/pyrealsense/core.pyx
+++ b/pyrealsense/core.pyx
@@ -2,15 +2,16 @@ import numpy as np
 cimport numpy as np
 from libc.string cimport memcpy
 from libcpp.map cimport map
+from libcpp cimport bool
 
-from pyrealsense.enum import Format
-from pyrealsense.enum import Stream
+from pyrealsense.enum import Format, Stream, Option
 
 
 cdef extern from "librealsense/rs.hpp" namespace "rs":
 
     ctypedef int StreamType 'rs::stream'
     ctypedef int FormatType 'rs::format'
+    ctypedef int OptionType 'rs::option'
 
     cdef cppclass context:
         context()
@@ -20,14 +21,21 @@ cdef extern from "librealsense/rs.hpp" namespace "rs":
     cdef cppclass device:
         const char* get_name()
         const char* get_serial()
+        const char* get_firmware_version()
         const char* get_usb_port_id()
+        const float get_depth_scale()
+
         void enable_stream(StreamType stream, int width, int height, FormatType format, int framerate)
         void disable_stream(StreamType stream)
         void start()
         void stop()
         void wait_for_frames()
         void* get_frame_data(StreamType stream)
-
+        void set_option(OptionType option, double value)
+        double get_option(OptionType option)
+        bool supports_option(OptionType option)
+        bool poll_for_frames()
+        int get_frame_timestamp(StreamType stream)
 
 cdef dict FORMAT_CONFIG = {
     Format.z16: (1, np.dtype('u2')),
@@ -68,9 +76,17 @@ cdef class Device:
         cdef const char* s = self._device.get_serial()
         return s.decode('UTF-8', 'strict')
 
+    cpdef unicode get_firmware_version(self):
+        cdef const char* s = self._device.get_firmware_version()
+        return s.decode('UTF-8', 'strict')
+
     cpdef unicode get_usb_port_id(self):
         cdef const char* s = self._device.get_usb_port_id()
         return s.decode('UTF-8', 'strict')
+
+    cpdef float get_depth_scale(self):
+        cdef float depth_scale = self._device.get_depth_scale()
+        return depth_scale
 
     cpdef void enable_stream(
             self, int stream, int width, int height, int fmt, int framerate):
@@ -105,3 +121,22 @@ cdef class Device:
             <void*>dst_ptr, <void*>src_ptr,
             <size_t>(width * height * channel * dtype.itemsize))
         return dst_arr
+
+    cpdef void set_option(self, int option, double value):
+        self._device.set_option(<OptionType>option, value)
+
+    cpdef double get_option(self, int option):
+        cdef double val = self._device.get_option(<OptionType>option)
+        return val
+
+    cpdef bool supports_option(self, int option):
+        cdef bool val = self._device.supports_option(<OptionType>option)
+        return val
+
+    cpdef bool poll_for_frames(self):
+        cdef bool ret = self._device.poll_for_frames()
+        return ret
+
+    cpdef int get_frame_timestamp(self, int stream):
+        cdef int timestamps = self._device.get_frame_timestamp(<StreamType>stream)
+        return timestamps

--- a/pyrealsense/enum.py
+++ b/pyrealsense/enum.py
@@ -1,27 +1,110 @@
-class Format:
-    any         = 0  
-    z16         = 1
-    disparity16 = 2
-    xyz32f      = 3
-    yuyv        = 4  
-    rgb8        = 5  
-    bgr8        = 6  
-    rgba8       = 7  
-    bgra8       = 8  
-    y8          = 9  
-    y16         = 10 
-    raw10       = 11
+class Stub:
+    pass
 
+def populate_class(items):
 
-class Stream:
-    depth                            = 0
-    color                            = 1
-    infrared                         = 2
-    infrared2                        = 3
-    points                           = 4
-    rectified_color                  = 5
-    color_aligned_to_depth           = 6
-    infrared2_aligned_to_depth       = 7
-    depth_aligned_to_color           = 8
-    depth_aligned_to_rectified_color = 9
-    depth_aligned_to_infrared2       = 10
+    cls = Stub()
+    cls.__dict__.update({ v: k for k, v in enumerate(items)})
+    return cls
+
+Stream = populate_class([
+    "depth",
+    "color",
+    "infrared",
+    "infrared2",
+    "fisheye",
+    "points",
+    "rectified_color",
+    "color_aligned_to_depth",
+    "infrared2_aligned_to_depth",
+    "depth_aligned_to_color",
+    "depth_aligned_to_rectified_color,",
+    "depth_aligned_to_infrared2",
+])
+
+Format = populate_class([
+    "any",
+    "z16",
+    "disparity16",
+    "xyz32f",
+    "yuyv",
+    "rgb8",
+    "bgr8",
+    "rgba8",
+    "bgra8",
+    "y8",
+    "y16",
+    "raw10",
+    "raw16",
+    "raw8",
+])
+
+Option = populate_class([
+    "color_backlight_compensation",
+    "color_brightness",
+    "color_contrast",
+    "color_exposure",
+    "color_gain",
+    "color_gamma",
+    "color_hue",
+    "color_saturation",
+    "color_sharpness",
+    "color_white_balance",
+    "color_enable_auto_exposure",
+    "color_enable_auto_white_balance",
+    "f200_laser_power",
+    "f200_accuracy",
+    "f200_motion_range",
+    "f200_filter_option",
+    "f200_confidence_threshold",
+    "f200_dynamic_fps",
+    "sr300_auto_range_enable_motion_versus_range",
+    "sr300_auto_range_enable_laser",
+    "sr300_auto_range_min_motion_versus_range",
+    "sr300_auto_range_max_motion_versus_range",
+    "sr300_auto_range_start_motion_versus_range",
+    "sr300_auto_range_min_laser",
+    "sr300_auto_range_max_laser",
+    "sr300_auto_range_start_laser",
+    "sr300_auto_range_upper_threshold",
+    "sr300_auto_range_lower_threshold",
+    "r200_lr_auto_exposure_enabled",
+    "r200_lr_gain",
+    "r200_lr_exposure",
+    "r200_emitter_enabled",
+    "r200_depth_units",
+    "r200_depth_clamp_min",
+    "r200_depth_clamp_max",
+    "r200_disparity_multiplier",
+    "r200_disparity_shift",
+    "r200_auto_exposure_mean_intensity_set_point",
+    "r200_auto_exposure_bright_ratio_set_point",
+    "r200_auto_exposure_kp_gain",
+    "r200_auto_exposure_kp_exposure",
+    "r200_auto_exposure_kp_dark_threshold",
+    "r200_auto_exposure_top_edge",
+    "r200_auto_exposure_bottom_edge",
+    "r200_auto_exposure_left_edge",
+    "r200_auto_exposure_right_edge",
+    "r200_depth_control_estimate_median_decrement",
+    "r200_depth_control_estimate_median_increment",
+    "r200_depth_control_median_threshold",
+    "r200_depth_control_score_minimum_threshold",
+    "r200_depth_control_score_maximum_threshold",
+    "r200_depth_control_texture_count_threshold",
+    "r200_depth_control_texture_difference_threshold",
+    "r200_depth_control_second_peak_threshold",
+    "r200_depth_control_neighbor_threshold",
+    "r200_depth_control_lr_threshold",
+    "fisheye_exposure",
+    "fisheye_gain",
+    "fisheye_strobe",
+    "fisheye_external_trigger",
+    "fisheye_color_auto_exposure",
+    "fisheye_color_auto_exposure_mode",
+    "fisheye_color_auto_exposure_rate",
+    "fisheye_color_auto_exposure_sample_rate",
+    "fisheye_color_auto_exposure_skip_frames",
+    "frames_queue_size",
+    "hardware_logger_enabled",
+])

--- a/pyrealsense/enum.py
+++ b/pyrealsense/enum.py
@@ -18,7 +18,7 @@ Stream = populate_class([
     "color_aligned_to_depth",
     "infrared2_aligned_to_depth",
     "depth_aligned_to_color",
-    "depth_aligned_to_rectified_color,",
+    "depth_aligned_to_rectified_color",
     "depth_aligned_to_infrared2",
 ])
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@ from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import numpy
+import sys
+
+extra_compile_args=['-Ofast', '-std=c++11'],
+if sys.platform == "darwin":
+    extra_compile_args.insert(0, "-mmacosx-version-min=10.9")
 
 ext_modules = [
     Extension(
@@ -10,7 +15,7 @@ ext_modules = [
         include_dirs=[numpy.get_include()],
         libraries=['realsense'],
         language='c++',
-        extra_compile_args=['-mmacosx-version-min=10.9', '-Ofast', '-std=c++11'],
+        extra_compile_args=['-Ofast', '-std=c++11'],
         extra_link_args=['-std=c++11']),
 ]
 


### PR DESCRIPTION
Added support for get_firmware_version, get_depth_scale, set_option, get_option, supports_option, poll_for_frames and get_frame_timestamp.

Also fixed compilation on Linux (e.g. parameterize MAC build flag).

Also modified Option, Format & Stream classes to be in sync with librealsense 1.9.7 include/rs.hpp header file. The header files seem not to have hardcoded integers anymore, but rather use array format. Hence added a conversion from string-array to a python class, maybe easier to diff/keep in sync with librealsense file.
